### PR TITLE
implements get_available_physical_addresses

### DIFF
--- a/open_lisa/api/api.py
+++ b/open_lisa/api/api.py
@@ -55,6 +55,11 @@ class OpenLISA:
                             "[OpenLISA][api][start] - getting specific instrument")
                         self._server_protocol.handle_get_instrument(
                             self._instruments_repository)
+                    elif command == COMMAND_GET_DETECTED_PHYSICAL_ADDRESSES:
+                        logging.debug(
+                            "[OpenLISA][api][start] - getting detected physical addresses")
+                        self._server_protocol.handle_get_detected_physical_addresses(
+                            self._instruments_repository)
                     elif command == COMMAND_CREATE_INSTRUMENT:
                         logging.debug(
                             "[OpenLISA][api][start] - creating new instrument")

--- a/open_lisa/protocol/server_protocol.py
+++ b/open_lisa/protocol/server_protocol.py
@@ -57,7 +57,7 @@ class ServerProtocol:
 
     def handle_get_detected_physical_addresses(self, instruments_repository: InstrumentRepository):
         try:
-            available_physicall_addresses = instruments_repository.get_available_physical_addresses()
+            available_physicall_addresses = instruments_repository.get_pyvisa_available_physical_addresses()
             self._message_protocol.send_msg(SUCCESS_RESPONSE)
             self._message_protocol.send_msg(
                 json.dumps(available_physicall_addresses))

--- a/open_lisa/protocol/server_protocol.py
+++ b/open_lisa/protocol/server_protocol.py
@@ -17,6 +17,7 @@ ERROR_RESPONSE = "ERROR"
 
 COMMAND_GET_INSTRUMENTS = "GET_INSTRUMENTS"
 COMMAND_GET_INSTRUMENT = "GET_INSTRUMENT"
+COMMAND_GET_DETECTED_PHYSICAL_ADDRESSES = "GET_DETECTED_PHYSICAL_ADDRESSES"
 COMMAND_CREATE_INSTRUMENT = "CREATE_INSTRUMENT"
 COMMAND_UPDATE_INSTRUMENT = "UPDATE_INSTRUMENT"
 COMMAND_DELETE_INSTRUMENT = "DELETE_INSTRUMENT"
@@ -53,6 +54,16 @@ class ServerProtocol:
     def handle_get_instruments(self, instruments_repository: InstrumentRepository):
         jsons_string = instruments_repository.get_all_as_json()
         self._message_protocol.send_msg(jsons_string)
+
+    def handle_get_detected_physical_addresses(self, instruments_repository: InstrumentRepository):
+        try:
+            available_physicall_addresses = instruments_repository.get_available_physical_addresses()
+            self._message_protocol.send_msg(SUCCESS_RESPONSE)
+            self._message_protocol.send_msg(
+                json.dumps(available_physicall_addresses))
+        except OpenLISAException as e:
+            self._message_protocol.send_msg(ERROR_RESPONSE)
+            self._message_protocol.send_msg(e.message)
 
     def handle_get_instrument(self, instruments_repository: InstrumentRepository):
         id = self._message_protocol.receive_msg()

--- a/open_lisa/repositories/instruments_repository.py
+++ b/open_lisa/repositories/instruments_repository.py
@@ -46,7 +46,7 @@ class InstrumentRepository(JSONRepository):
 
         return instruments
 
-    def get_available_physical_addresses(self):
+    def get_pyvisa_available_physical_addresses(self):
         instrument_dicts = super().get_all()
 
         # Gets only the physical addresses of the registered instruments


### PR DESCRIPTION
Se implementa funcionalidad para proveer direcciones físicas detectadas por pyvisa que no fueron registradas aún
- Se agrega información de ResourceInfo que provee pyvisa
- No se implementa test ya que habría que mockear pyvisa lo cual no es trivial y no resultaría en un test que aporte mucho valor

Ejemplo de lo retornado:
```
[{'physical_address': 'ASRL/dev/cu.Bluetooth-Incoming-Port::INSTR', 'interface_type': 'InterfaceType.asrl', 'interface_board_number': 'None', 'resource_class': 'INSTR', 'resource_name': 'ASRL/dev/cu.Bluetooth-Incoming-Port::INSTR', 'alias': 'None'}, {'physical_address': 'ASRL/dev/cu.SOUNDPEATSTruengine3SE-::INSTR', 'interface_type': 'InterfaceType.asrl', 'interface_board_number': 'None', 'resource_class': 'INSTR', 'resource_name': 'ASRL/dev/cu.SOUNDPEATSTruengine3SE-::INSTR', 'alias': 'None'}]
```

Cambio en la SDK:
https://github.com/aalvarezwindey/Open-LISA-SDK/commit/3c5d9f9649a59709862df31fe1352d156332302d